### PR TITLE
ci: ignore only changes in index.rst.txt

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,8 +38,7 @@ jobs:
         rm -r docs
         cp -r ../python-client/docs/_build/html ./docs
         git --no-pager diff --stat
-        if [ -z "$(git --no-pager diff --stat -- . ':(exclude)docs/_sources/index.rst.txt')" ]; then git checkout .; fi
-        if (git --no-pager diff --stat | grep -q "2 files changed, 2 insertions(+), 2 deletions(-)"); then exit 1; fi
+        if (git --no-pager diff --stat | grep -q "docs/_sources/index.rst.txt | 2 +-"); then exit 1; fi
       working-directory: python-client-sphinx
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,6 +38,7 @@ jobs:
         rm -r docs
         cp -r ../python-client/docs/_build/html ./docs
         git --no-pager diff --stat
+        if [ -z "$(git --no-pager diff --stat -- . ':(exclude)docs/_sources/index.rst.txt')" ]; then git checkout .; fi
         if (git --no-pager diff --stat | grep -q "2 files changed, 2 insertions(+), 2 deletions(-)"); then exit 1; fi
       working-directory: python-client-sphinx
     - name: Create Pull Request


### PR DESCRIPTION
https://github.com/appium/python-client-sphinx/issues/8 and https://github.com/appium/python-client-sphinx/pull/10

For now, index.rst.txt has metadata change like https://github.com/appium/python-client-sphinx/pull/10 even when no changes in other doc files.

This change simply reset the change only when changes exist in `index.rst.txt`.
If we have documentation changes, then diff should not be only `index.rst.txt` so far, so this may be a reasonable small script to ignore only metadata (time) change.